### PR TITLE
Bring elCap changes up to date

### DIFF
--- a/360Controller/ChatPad.h
+++ b/360Controller/ChatPad.h
@@ -30,24 +30,24 @@ class ChatPadKeyboardClass : public IOHIDDevice
 private:
 
 public:
-    virtual bool start(IOService *provider);
+    virtual bool start(IOService *provider) override;
 
     // IOHidDevice methods
-    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const;
+    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const override;
 
-    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0);
-    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options);
+    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0) override;
+    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options) override;
 
-	virtual IOReturn handleReport(IOMemoryDescriptor *report, IOHIDReportType reportType = kIOHIDReportTypeInput, IOOptionBits options = 0);
+	virtual IOReturn handleReport(IOMemoryDescriptor *report, IOHIDReportType reportType = kIOHIDReportTypeInput, IOOptionBits options = 0) override;
 
-    virtual OSString* newManufacturerString() const;
-    virtual OSNumber* newPrimaryUsageNumber() const;
-    virtual OSNumber* newPrimaryUsagePageNumber() const;
-    virtual OSNumber* newProductIDNumber() const;
-    virtual OSString* newProductString() const;
-    virtual OSString* newSerialNumberString() const;
-    virtual OSString* newTransportString() const;
-    virtual OSNumber* newVendorIDNumber() const;
+    virtual OSString* newManufacturerString() const override;
+    virtual OSNumber* newPrimaryUsageNumber() const override;
+    virtual OSNumber* newPrimaryUsagePageNumber() const override;
+    virtual OSNumber* newProductIDNumber() const override;
+    virtual OSString* newProductString() const override;
+    virtual OSString* newSerialNumberString() const override;
+    virtual OSString* newTransportString() const override;
+    virtual OSNumber* newVendorIDNumber() const override;
 
-    virtual OSNumber* newLocationIDNumber() const;
+    virtual OSNumber* newLocationIDNumber() const override;
 };

--- a/360Controller/Controller.h
+++ b/360Controller/Controller.h
@@ -34,29 +34,29 @@ private:
     OSString* getDeviceString(UInt8 index,const char *def=NULL) const;
 
 public:
-    virtual bool start(IOService *provider);
+    virtual bool start(IOService *provider) override;
 
-    virtual IOReturn setProperties(OSObject *properties);
+    virtual IOReturn setProperties(OSObject *properties) override;
 
-    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const;
+    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const override;
 
-    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0);
-    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options);
+    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0) override;
+    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options) override;
     virtual IOReturn handleReport(
                                   IOMemoryDescriptor * report,
                                   IOHIDReportType      reportType = kIOHIDReportTypeInput,
-                                  IOOptionBits         options    = 0 );
+                                  IOOptionBits         options    = 0 ) override;
 
-    virtual OSString* newManufacturerString() const;
-    virtual OSNumber* newPrimaryUsageNumber() const;
-    virtual OSNumber* newPrimaryUsagePageNumber() const;
-    virtual OSNumber* newProductIDNumber() const;
-    virtual OSString* newProductString() const;
-    virtual OSString* newSerialNumberString() const;
-    virtual OSString* newTransportString() const;
-    virtual OSNumber* newVendorIDNumber() const;
+    virtual OSString* newManufacturerString() const override;
+    virtual OSNumber* newPrimaryUsageNumber() const override;
+    virtual OSNumber* newPrimaryUsagePageNumber() const override;
+    virtual OSNumber* newProductIDNumber() const override;
+    virtual OSString* newProductString() const override;
+    virtual OSString* newSerialNumberString() const override;
+    virtual OSString* newTransportString() const override;
+    virtual OSNumber* newVendorIDNumber() const override;
 
-    virtual OSNumber* newLocationIDNumber() const;
+    virtual OSNumber* newLocationIDNumber() const override;
 
     virtual void remapButtons(void *buffer);
     virtual void remapAxes(void *buffer);
@@ -66,7 +66,7 @@ public:
 class Xbox360Pretend360Class : public Xbox360ControllerClass
 {
     OSDeclareDefaultStructors(Xbox360Pretend360Class)
-    
+
 public:
     virtual OSString* newProductString() const;
     virtual OSNumber* newProductIDNumber() const;
@@ -83,16 +83,16 @@ private:
     UInt32 repeatCount;
 
 public:
-    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0);
+    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0) override;
     virtual IOReturn handleReport(
                                   IOMemoryDescriptor * report,
                                   IOHIDReportType      reportType = kIOHIDReportTypeInput,
-                                  IOOptionBits         options    = 0 );
+                                  IOOptionBits         options    = 0 ) override;
 
-    virtual OSString* newManufacturerString() const;
-    virtual OSNumber* newProductIDNumber() const;
-    virtual OSNumber* newVendorIDNumber() const;
-    virtual OSString* newProductString() const;
+    virtual OSString* newManufacturerString() const override;
+    virtual OSNumber* newProductIDNumber() const override;
+    virtual OSNumber* newVendorIDNumber() const override;
+    virtual OSString* newProductString() const override;
 };
 
 
@@ -109,11 +109,11 @@ protected:
     UInt16 convertButtonPacket(UInt16 buttons);
 
 public:
-    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0);
+    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0) override;
     virtual IOReturn handleReport(
                                   IOMemoryDescriptor * report,
                                   IOHIDReportType      reportType = kIOHIDReportTypeInput,
-                                  IOOptionBits         options    = 0 );
+                                  IOOptionBits         options    = 0 ) override;
 
     virtual void convertFromXboxOne(void *buffer, UInt8 packetSize);
     virtual OSString* newProductString() const;

--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -34,7 +34,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>1043</integer>
 			<key>idVendor</key>
@@ -54,7 +54,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64252</integer>
 			<key>idVendor</key>
@@ -74,7 +74,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63751</integer>
 			<key>idVendor</key>
@@ -94,7 +94,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64253</integer>
 			<key>idVendor</key>
@@ -114,7 +114,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>313</integer>
 			<key>idVendor</key>
@@ -134,7 +134,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18264</integer>
 			<key>idVendor</key>
@@ -154,7 +154,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21766</integer>
 			<key>idVendor</key>
@@ -174,7 +174,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>16144</integer>
 			<key>idVendor</key>
@@ -194,7 +194,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>1537</integer>
 			<key>idVendor</key>
@@ -225,7 +225,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>65535</integer>
 			<key>idVendor</key>
@@ -245,7 +245,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>654</integer>
 			<key>idVendor</key>
@@ -265,7 +265,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>655</integer>
 			<key>idVendor</key>
@@ -285,7 +285,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>672</integer>
 			<key>idVendor</key>
@@ -305,7 +305,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>10</integer>
 			<key>idVendor</key>
@@ -325,7 +325,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21773</integer>
 			<key>idVendor</key>
@@ -345,7 +345,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>1025</integer>
 			<key>idVendor</key>
@@ -365,7 +365,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>769</integer>
 			<key>idVendor</key>
@@ -385,7 +385,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>770</integer>
 			<key>idVendor</key>
@@ -405,7 +405,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63745</integer>
 			<key>idVendor</key>
@@ -425,7 +425,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>62209</integer>
 			<key>idVendor</key>
@@ -445,7 +445,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18248</integer>
 			<key>idVendor</key>
@@ -465,7 +465,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>13</integer>
 			<key>idVendor</key>
@@ -485,7 +485,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>62723</integer>
 			<key>idVendor</key>
@@ -505,7 +505,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21762</integer>
 			<key>idVendor</key>
@@ -525,7 +525,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>10</integer>
 			<key>idVendor</key>
@@ -545,7 +545,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>62725</integer>
 			<key>idVendor</key>
@@ -565,7 +565,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>13</integer>
 			<key>idVendor</key>
@@ -585,7 +585,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>62721</integer>
 			<key>idVendor</key>
@@ -605,7 +605,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21760</integer>
 			<key>idVendor</key>
@@ -625,7 +625,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>12</integer>
 			<key>idVendor</key>
@@ -645,7 +645,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>103</integer>
 			<key>idVendor</key>
@@ -665,7 +665,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>99</integer>
 			<key>idVendor</key>
@@ -685,7 +685,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21774</integer>
 			<key>idVendor</key>
@@ -705,7 +705,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>120</integer>
 			<key>idVendor</key>
@@ -725,7 +725,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>27</integer>
 			<key>idVendor</key>
@@ -745,7 +745,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>62722</integer>
 			<key>idVendor</key>
@@ -765,7 +765,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21760</integer>
 			<key>idVendor</key>
@@ -785,7 +785,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64001</integer>
 			<key>idVendor</key>
@@ -805,7 +805,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>304</integer>
 			<key>idVendor</key>
@@ -825,7 +825,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>48879</integer>
 			<key>idVendor</key>
@@ -845,7 +845,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>4</integer>
 			<key>idVendor</key>
@@ -865,7 +865,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>49730</integer>
 			<key>idVendor</key>
@@ -885,7 +885,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>49693</integer>
 			<key>idVendor</key>
@@ -905,7 +905,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>49694</integer>
 			<key>idVendor</key>
@@ -925,7 +925,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>49695</integer>
 			<key>idVendor</key>
@@ -945,7 +945,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>49761</integer>
 			<key>idVendor</key>
@@ -965,7 +965,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61475</integer>
 			<key>idVendor</key>
@@ -985,7 +985,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61497</integer>
 			<key>idVendor</key>
@@ -1005,7 +1005,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>46904</integer>
 			<key>idVendor</key>
@@ -1025,7 +1025,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61465</integer>
 			<key>idVendor</key>
@@ -1045,7 +1045,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61477</integer>
 			<key>idVendor</key>
@@ -1065,7 +1065,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61479</integer>
 			<key>idVendor</key>
@@ -1085,7 +1085,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61486</integer>
 			<key>idVendor</key>
@@ -1105,7 +1105,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61498</integer>
 			<key>idVendor</key>
@@ -1125,7 +1125,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61503</integer>
 			<key>idVendor</key>
@@ -1145,7 +1145,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61568</integer>
 			<key>idVendor</key>
@@ -1165,7 +1165,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61506</integer>
 			<key>idVendor</key>
@@ -1185,7 +1185,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61502</integer>
 			<key>idVendor</key>
@@ -1205,7 +1205,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18198</integer>
 			<key>idVendor</key>
@@ -1225,7 +1225,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63746</integer>
 			<key>idVendor</key>
@@ -1245,7 +1245,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61642</integer>
 			<key>idVendor</key>
@@ -1265,7 +1265,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18230</integer>
 			<key>idVendor</key>
@@ -1285,7 +1285,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18230</integer>
 			<key>idVendor</key>
@@ -1305,7 +1305,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61462</integer>
 			<key>idVendor</key>
@@ -1325,7 +1325,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>39025</integer>
 			<key>idVendor</key>
@@ -1345,7 +1345,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18214</integer>
 			<key>idVendor</key>
@@ -1365,7 +1365,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>672</integer>
 			<key>idVendor</key>
@@ -1385,7 +1385,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>649</integer>
 			<key>idVendor</key>
@@ -1405,7 +1405,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>648</integer>
 			<key>idVendor</key>
@@ -1425,7 +1425,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>645</integer>
 			<key>idVendor</key>
@@ -1445,7 +1445,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>514</integer>
 			<key>idVendor</key>
@@ -1465,7 +1465,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>647</integer>
 			<key>idVendor</key>
@@ -1485,7 +1485,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>648</integer>
 			<key>idVendor</key>
@@ -1505,7 +1505,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>721</integer>
 			<key>idVendor</key>
@@ -1525,7 +1525,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>733</integer>
 			<key>idVendor</key>
@@ -1545,7 +1545,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>746</integer>
 			<key>idVendor</key>
@@ -1565,7 +1565,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>739</integer>
 			<key>idVendor</key>
@@ -1585,7 +1585,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>22000</integer>
 			<key>idVendor</key>
@@ -1605,7 +1605,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63744</integer>
 			<key>idVendor</key>
@@ -1625,7 +1625,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>275</integer>
 			<key>idVendor</key>
@@ -1645,7 +1645,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63744</integer>
 			<key>idVendor</key>
@@ -1665,7 +1665,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>531</integer>
 			<key>idVendor</key>
@@ -1685,7 +1685,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>769</integer>
 			<key>idVendor</key>
@@ -1705,7 +1705,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>305</integer>
 			<key>idVendor</key>
@@ -1725,7 +1725,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>327</integer>
 			<key>idVendor</key>
@@ -1745,7 +1745,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63747</integer>
 			<key>idVendor</key>
@@ -1765,7 +1765,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63748</integer>
 			<key>idVendor</key>
@@ -1785,7 +1785,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>314</integer>
 			<key>idVendor</key>
@@ -1805,7 +1805,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>348</integer>
 			<key>idVendor</key>
@@ -1825,7 +1825,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>16138</integer>
 			<key>idVendor</key>
@@ -1845,7 +1845,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21399</integer>
 			<key>idVendor</key>
@@ -1865,7 +1865,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>16128</integer>
 			<key>idVendor</key>
@@ -1885,7 +1885,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21274</integer>
 			<key>idVendor</key>
@@ -1905,7 +1905,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21248</integer>
 			<key>idVendor</key>
@@ -1925,7 +1925,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21530</integer>
 			<key>idVendor</key>
@@ -1945,7 +1945,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21562</integer>
 			<key>idVendor</key>
@@ -1965,7 +1965,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21546</integer>
 			<key>idVendor</key>
@@ -1985,7 +1985,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>48879</integer>
 			<key>idVendor</key>
@@ -2005,7 +2005,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>22</integer>
 			<key>idVendor</key>
@@ -2025,7 +2025,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>62724</integer>
 			<key>idVendor</key>
@@ -2045,7 +2045,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>62726</integer>
 			<key>idVendor</key>
@@ -2065,7 +2065,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>2560</integer>
 			<key>idVendor</key>
@@ -2085,7 +2085,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>20480</integer>
 			<key>idVendor</key>
@@ -2105,7 +2105,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64769</integer>
 			<key>idVendor</key>
@@ -2125,7 +2125,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64769</integer>
 			<key>idVendor</key>
@@ -2145,7 +2145,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64768</integer>
 			<key>idVendor</key>
@@ -2165,7 +2165,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64768</integer>
 			<key>idVendor</key>
@@ -2185,7 +2185,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>65024</integer>
 			<key>idVendor</key>
@@ -2205,7 +2205,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>23812</integer>
 			<key>idVendor</key>
@@ -2225,7 +2225,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>2563</integer>
 			<key>idVendor</key>
@@ -2245,7 +2245,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63489</integer>
 			<key>idVendor</key>
@@ -2265,7 +2265,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>672</integer>
 			<key>idVendor</key>
@@ -2285,7 +2285,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>3</integer>
 			<key>idVendor</key>
@@ -2305,7 +2305,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>2</integer>
 			<key>idVendor</key>
@@ -2325,7 +2325,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>287</integer>
 			<key>idVendor</key>
@@ -2345,7 +2345,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>543</integer>
 			<key>idVendor</key>
@@ -2365,7 +2365,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>64254</integer>
 			<key>idVendor</key>
@@ -2385,7 +2385,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>326</integer>
 			<key>idVendor</key>
@@ -2405,7 +2405,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>582</integer>
 			<key>idVendor</key>
@@ -2425,7 +2425,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>838</integer>
 			<key>idVendor</key>
@@ -2445,7 +2445,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>13</integer>
 			<key>idVendor</key>
@@ -2465,7 +2465,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61480</integer>
 			<key>idVendor</key>
@@ -2485,7 +2485,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18216</integer>
 			<key>idVendor</key>
@@ -2505,7 +2505,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18200</integer>
 			<key>idVendor</key>
@@ -2525,7 +2525,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>18232</integer>
 			<key>idVendor</key>
@@ -2545,7 +2545,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61496</integer>
 			<key>idVendor</key>
@@ -2565,7 +2565,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63288</integer>
 			<key>idVendor</key>
@@ -2585,7 +2585,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>61501</integer>
 			<key>idVendor</key>
@@ -2605,7 +2605,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>52009</integer>
 			<key>idVendor</key>
@@ -2625,7 +2625,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>51970</integer>
 			<key>idVendor</key>
@@ -2645,7 +2645,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>1</integer>
 			<key>idVendor</key>
@@ -2665,7 +2665,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>3</integer>
 			<key>idVendor</key>
@@ -2685,7 +2685,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>513</integer>
 			<key>idVendor</key>
@@ -2705,7 +2705,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>23296</integer>
 			<key>idVendor</key>
@@ -2725,7 +2725,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>23299</integer>
 			<key>idVendor</key>
@@ -2745,7 +2745,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>45862</integer>
 			<key>idVendor</key>
@@ -2765,7 +2765,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>23298</integer>
 			<key>idVendor</key>
@@ -2785,7 +2785,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>63750</integer>
 			<key>idVendor</key>
@@ -2805,7 +2805,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21258</integer>
 			<key>idVendor</key>
@@ -2825,7 +2825,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 			<key>idProduct</key>
 			<integer>21562</integer>
 			<key>idVendor</key>
@@ -2837,15 +2837,17 @@
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>com.apple.iokit.IOHIDFamily</key>
-		<string>1.2</string>
-		<key>com.apple.iokit.IOUSBFamily</key>
-		<string>1.8</string>
+		<string>2.0</string>
+		<key>com.apple.iokit.IOUSBHostFamily</key>
+		<string>1.0.1</string>
 		<key>com.apple.kpi.iokit</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 		<key>com.apple.kpi.libkern</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 		<key>com.apple.kpi.mach</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
+		<key>com.apple.kpi.bsd</key>
+		<string>15.6</string>
 	</dict>
 </dict>
 </plist>

--- a/360Controller/_60Controller.h
+++ b/360Controller/_60Controller.h
@@ -24,8 +24,8 @@
 #define __XBOX360CONTROLLER_H__
 
 #include <IOKit/hid/IOHIDDevice.h>
-#include <IOKit/usb/IOUSBDevice.h>
-#include <IOKit/usb/IOUSBInterface.h>
+#include <IOKit/usb/IOUSBHostDevice.h>
+#include <IOKit/usb/IOUSBHostInterface.h>
 #include "ControlStruct.h"
 
 class Xbox360ControllerClass;
@@ -83,17 +83,17 @@ protected:
         Xbox360Pretend360 = 4,
     } CONTROLLER_TYPE;
 
-    IOUSBDevice *device;
+    IOUSBHostDevice *device;
     IOLock *mainLock;
 
-    // Joypad
-    IOUSBInterface *interface;
-    IOUSBPipe *inPipe,*outPipe;
+	// Joypad
+    IOUSBHostInterface *interface;
+    IOUSBHostPipe *inPipe,*outPipe;
     IOBufferMemoryDescriptor *inBuffer;
 
-    // Keyboard
-    IOUSBInterface *serialIn;
-    IOUSBPipe *serialInPipe;
+	// Keyboard
+	IOUSBHostInterface *serialIn;
+	IOUSBHostPipe *serialInPipe;
     IOBufferMemoryDescriptor *serialInBuffer;
     IOTimerEventSource *serialTimer;
     bool serialToggle, serialHeard, serialActive;
@@ -124,21 +124,21 @@ public:
     UInt8 outCounter = 6;
 
     // this is from the IORegistryEntry - no provider yet
-    virtual bool init(OSDictionary *propTable);
-    virtual void free(void);
+    virtual bool init(OSDictionary *propTable) override;
+    virtual void free(void) override;
 
-    bool start(IOService *provider);
-    void stop(IOService *provider);
+	bool start(IOService *provider) override;
+	void stop(IOService *provider) override;
 
     // IOKit methods. These methods are defines in <IOKit/IOService.h>
 
-    virtual IOReturn setProperties(OSObject *properties);
+    virtual IOReturn setProperties(OSObject *properties) override;
 
-    virtual IOReturn message(UInt32 type, IOService *provider, void *argument);
+    virtual IOReturn message(UInt32 type, IOService *provider, void *argument) override;
 
-    virtual bool didTerminate(IOService *provider, IOOptionBits options, bool *defer);
+    virtual bool didTerminate(IOService *provider, IOOptionBits options, bool *defer) override;
 
-    // Hooks
+	// Hooks
     virtual void ReadComplete(void *parameter,IOReturn status,UInt32 bufferSizeRemaining);
     virtual void WriteComplete(void *parameter,IOReturn status,UInt32 bufferSizeRemaining);
 

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -68,7 +68,7 @@ static UInt8 previousMapping[15];
 - (void)cancelMappingWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)prefPref {
     pref = prefPref;
     remappingButton = button;
-    
+
     [self restorePreviousMapping];
     [self stopMapping];
 }

--- a/Wireless360Controller/Info.plist
+++ b/Wireless360Controller/Info.plist
@@ -42,15 +42,15 @@
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>com.apple.iokit.IOHIDFamily</key>
-		<string>1.2</string>
+		<string>2.0</string>
 		<key>com.apple.kpi.iokit</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 		<key>com.apple.kpi.libkern</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 		<key>com.apple.kpi.mach</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 		<key>com.mice.driver.WirelessGamingReceiver</key>
-		<string>1.0.0d1</string>
+		<string>1.0d15</string>
 	</dict>
 </dict>
 </plist>

--- a/Wireless360Controller/Wireless360Controller.cpp
+++ b/Wireless360Controller/Wireless360Controller.cpp
@@ -132,7 +132,7 @@ void Wireless360Controller::readSettings(void)
     if (number != NULL) mapping[14] = number->unsigned32BitValue();
     value = OSDynamicCast(OSBoolean, dataDictionary->getObject("SwapSticks"));
     if (value != NULL) swapSticks = value->getValue();
-    
+
     noMapping = true;
     UInt8 normalMapping[15] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15 };
     for (int i = 0; i < 15; i++)

--- a/Wireless360Controller/Wireless360Controller.h
+++ b/Wireless360Controller/Wireless360Controller.h
@@ -29,25 +29,25 @@ class Wireless360Controller : public WirelessHIDDevice
 {
     OSDeclareDefaultStructors(Wireless360Controller);
 public:
-    bool init(OSDictionary *propTable = NULL);
+    bool init(OSDictionary *propTable = NULL) override;
 
     void SetRumbleMotors(unsigned char large, unsigned char small);
 
-    IOReturn setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options);
-    IOReturn newReportDescriptor(IOMemoryDescriptor ** descriptor ) const;
+    IOReturn setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) override;
+    IOReturn newReportDescriptor(IOMemoryDescriptor ** descriptor ) const override;
 
-    IOReturn setProperties(OSObject *properties);
+    IOReturn setProperties(OSObject *properties) override;
 
-    virtual OSString* newManufacturerString() const;
-    virtual OSNumber* newPrimaryUsageNumber() const;
-    virtual OSNumber* newPrimaryUsagePageNumber() const;
-    virtual OSNumber* newProductIDNumber() const;
-    virtual OSString* newProductString() const;
-    virtual OSString* newTransportString() const;
-    virtual OSNumber* newVendorIDNumber() const;
+    virtual OSString* newManufacturerString() const override;
+    virtual OSNumber* newPrimaryUsageNumber() const override;
+    virtual OSNumber* newPrimaryUsagePageNumber() const override;
+    virtual OSNumber* newProductIDNumber() const override;
+    virtual OSString* newProductString() const override;
+    virtual OSString* newTransportString() const override;
+    virtual OSNumber* newVendorIDNumber() const override;
 protected:
     void readSettings(void);
-    void receivedHIDupdate(unsigned char *data, int length);
+    void receivedHIDupdate(unsigned char *data, int length) override;
 
     // Settings
     bool invertLeftX,invertLeftY;

--- a/WirelessGamingReceiver/Info.plist
+++ b/WirelessGamingReceiver/Info.plist
@@ -33,7 +33,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 		</dict>
 		<key>WirelessGamingReceiverForWindowsAlternate</key>
 		<dict>
@@ -48,7 +48,7 @@
 			<key>IOKitDebug</key>
 			<integer>65535</integer>
 			<key>IOProviderClass</key>
-			<string>IOUSBDevice</string>
+			<string>IOUSBHostDevice</string>
 		</dict>
 	</dict>
 	<key>OSBundleCompatibleVersion</key>
@@ -56,15 +56,15 @@
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>com.apple.iokit.IOHIDFamily</key>
-		<string>1.2</string>
-		<key>com.apple.iokit.IOUSBFamily</key>
-		<string>1.8</string>
+		<string>2.0</string>
+		<key>com.apple.iokit.IOUSBHostFamily</key>
+		<string>1.0.1</string>
 		<key>com.apple.kpi.iokit</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 		<key>com.apple.kpi.libkern</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 		<key>com.apple.kpi.mach</key>
-		<string>8.0.0</string>
+		<string>15.6</string>
 	</dict>
 </dict>
 </plist>

--- a/WirelessGamingReceiver/WirelessDevice.h
+++ b/WirelessGamingReceiver/WirelessDevice.h
@@ -34,7 +34,7 @@ class WirelessDevice : public IOService
     OSDeclareDefaultStructors(WirelessDevice);
 
 public:
-    bool init(OSDictionary *dictionary = 0);
+    bool init(OSDictionary *dictionary = 0) override;
 
     // Controller interface
     bool IsDataAvailable(void);

--- a/WirelessGamingReceiver/WirelessGamingReceiver.h
+++ b/WirelessGamingReceiver/WirelessGamingReceiver.h
@@ -23,8 +23,8 @@
 #ifndef __WIRELESSGAMINGRECEIVER_H__
 #define __WIRELESSGAMINGRECEIVER_H__
 
-#include <IOKit/usb/IOUSBDevice.h>
-#include <IOKit/usb/IOUSBInterface.h>
+#include <IOKit/usb/IOUSBHostDevice.h>
+#include <IOKit/usb/IOUSBHostInterface.h>
 
 // This value is defined by the hardware and fixed
 #define WIRELESS_CONNECTIONS        4
@@ -34,12 +34,12 @@ class WirelessDevice;
 typedef struct WIRELESS_CONNECTION
 {
     // Controller
-    IOUSBInterface *controller;
-    IOUSBPipe *controllerIn, *controllerOut;
+    IOUSBHostInterface *controller;
+    IOUSBHostPipe *controllerIn, *controllerOut;
 
     // Mystery
-    IOUSBInterface *other;
-    IOUSBPipe *otherIn, *otherOut;
+    IOUSBHostInterface *other;
+    IOUSBHostPipe *otherIn, *otherOut;
 
     // Runtime data
     OSArray *inputArray;
@@ -52,10 +52,10 @@ class WirelessGamingReceiver : public IOService
 {
     OSDeclareDefaultStructors(WirelessGamingReceiver);
 public:
-    bool start(IOService *provider);
-    void stop(IOService *provider);
+    bool start(IOService *provider) override;
+    void stop(IOService *provider) override;
 
-    IOReturn message(UInt32 type,IOService *provider,void *argument);
+    IOReturn message(UInt32 type,IOService *provider,void *argument) override;
 
     // For WirelessDevice to use
     OSNumber* newLocationIDNumber() const;
@@ -67,7 +67,7 @@ private:
     bool QueueWrite(int index, const void *bytes, UInt32 length);
 
 private:
-    IOUSBDevice *device;
+    IOUSBHostDevice *device;
     WIRELESS_CONNECTION connections[WIRELESS_CONNECTIONS];
     int connectionCount;
 
@@ -82,7 +82,7 @@ private:
 
     void ReleaseAll(void);
 
-    bool didTerminate(IOService *provider, IOOptionBits options, bool *defer);
+    bool didTerminate(IOService *provider, IOOptionBits options, bool *defer) override;
 
     static void _ReadComplete(void *target, void *parameter, IOReturn status, UInt32 bufferSizeRemaining);
     static void _WriteComplete(void *target, void *parameter, IOReturn status, UInt32 bufferSizeRemaining);

--- a/WirelessGamingReceiver/WirelessHIDDevice.h
+++ b/WirelessGamingReceiver/WirelessHIDDevice.h
@@ -35,13 +35,13 @@ public:
     void PowerOff(void);
     unsigned char GetBatteryLevel(void);
 
-    IOReturn setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options);
+    IOReturn setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) override;
 
-    OSNumber* newLocationIDNumber() const;
-    OSString* newSerialNumberString() const;
+    OSNumber* newLocationIDNumber() const override;
+    OSString* newSerialNumberString() const override;
 protected:
-    bool handleStart(IOService *provider);
-    void handleStop(IOService *provider);
+    bool handleStart(IOService *provider) override;
+    void handleStop(IOService *provider) override;
     virtual void receivedData(void);
     virtual void receivedMessage(IOMemoryDescriptor *data);
     virtual void receivedUpdate(unsigned char type, unsigned char *data);


### PR DESCRIPTION
I had to squash my commit history because git is a constant thorn in my side, but this _should_ get the elCap changes back into line with what the main 360Controller repo is at now.

A couple of things still remain that I haven't fixed/checked.
1. Wired Xbox 360 Controllers, and to that extent Wired Original Xbox controllers. I don't own any, so I can't test them. I had trouble with Xbox One controllers to the point that I needed to check `bInterfaceNumber`, otherwise I would get the wrong endpoint. So a quick check over those to make sure that they aren't suffering from the same issues would be helpful.
2. Wireless Xbox 360 Controllers pair but don't exchange button packets. I'm not sure what the problem is here, but I thought you may know more about this than I do so you might want to take a shot at it. You can still turn the controller off from the Preference Pane, which is a weird quirk that might help in debugging the controller.
3. I was really hoping these changes would alleviate the need for the symbolic link to `/System/Library/Extensions/`, but it appears that it didn't. Rumble works with Xbox One controllers when the symbolic link is in place.
